### PR TITLE
Add extra types for release trigger

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,7 +3,7 @@ name: Docker Image CI
 on:
   push:
   release:
-    types: [published]
+    types: [published,created,edited,prereleased]
 
 jobs:
   build:
@@ -17,6 +17,6 @@ jobs:
         docker login docker.pkg.github.com --username ${GITHUB_ACTOR} --password ${GITHUB_TOKEN}
         docker tag xnat-tools:${GITHUB_SHA} docker.pkg.github.com/brown-bnc/xnat-tools/xnat-tools:${GITHUB_REF:11}
         docker push docker.pkg.github.com/brown-bnc/xnat-tools/xnat-tools:${GITHUB_REF:11}
-      if: github.event_name == 'release' && github.event.type == 'published'
+      if: github.event_name == 'release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The published trigger was too tight, we didn't push the image on `created`. This should force the release to be created on creation, publish, edit or prerelease.