### PR TITLE
Sort sequence list from XNAT

### DIFF
--- a/tests/test_seqlist.py
+++ b/tests/test_seqlist.py
@@ -1,0 +1,43 @@
+from xnat_tools import __version__
+import subprocess
+import os
+import shutil
+import shlex
+import json
+from dotenv import load_dotenv
+load_dotenv()
+
+
+def test_seqlist():
+    """Integration test for sequence list"""
+    xnat_user = os.environ.get("XNAT_USER", "testuser")
+    xnat_pass = os.environ.get("XNAT_PASS", "")
+    session = os.environ.get("XNAT_SESSION", "XNAT2_E00004")
+    session_suffix = os.environ.get("XNAT_SESSION_SUFFIX", "01")
+    bids_root_dir = os.environ.get("XNAT_BIDS_ROOT", "./tests/xnat2bids")
+    sequence = 8
+
+    if os.path.exists(bids_root_dir):
+        shutil.rmtree(bids_root_dir, ignore_errors=True)
+    
+    os.mkdir(bids_root_dir)
+
+    xnat2bids_cmd = f"xnat2bids --user {xnat_user} --password {xnat_pass} \
+                      --session {session} --session_suffix {session_suffix} \
+                      --bids_root_dir {bids_root_dir} --seqlist {sequence} -vv"
+
+
+    xnat2bids_split_cmd = shlex.split(xnat2bids_cmd)
+    
+    cmd = subprocess.run(xnat2bids_split_cmd, check=True)
+
+    xnat_export_path = f"tests/xnat2bids/shenhav/study-201226/xnat-export/sub-tcb2006/ses-{session_suffix}/func-bold_task-TSSblock_acq-2dot4mm-SMS4TR1200AP_run+"
+
+    assert os.path.isdir(os.path.join(os.getcwd(), xnat_export_path))
+    for f in os.listdir(os.path.join(os.getcwd(), xnat_export_path)):
+        dicom_sequence = int(f.split('-')[1])
+        print(dicom_sequence)
+        assert dicom_sequence == sequence
+
+    #cleanup output -- for debugging coment this out
+    shutil.rmtree(bids_root_dir, ignore_errors=True)

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -3,7 +3,7 @@ Filename: /dicom2bids.py
 Path: xnat-dicom2bids-session
 Created Date: Monday, August 26th 2019, 10:12:40 am
 Maintainer: Isabel Restrepo
-Descriptyion: Export a XNAT session into BIDS directory format
+Description: Export a XNAT session into BIDS directory format
 
 
 Original file lives here: https://bitbucket.org/nrg_customizations/nrg_pipeline_dicomtobids/src/default/scripts/catalog/DicomToBIDS/scripts/dcm2bids_wholeSession.py

--- a/xnat_tools/xnat_utils.py
+++ b/xnat_tools/xnat_utils.py
@@ -72,16 +72,11 @@ def get_scan_ids(connection, host, session):
     _logger.info("------------------------------------------------")
     _logger.info(f"Get scans.")
     r = get(connection, host + "/data/experiments/%s/scans" % session, params={"format": "json"})
-    scanRequestResultList = r.json()["ResultSet"]["Result"]
+    scanRequestResultList = sorted(r.json()["ResultSet"]["Result"], key=lambda x: int(x['ID']))
     scanIDList = [scan['ID'] for scan in scanRequestResultList]
     seriesDescList = [scan['series_description'] for scan in scanRequestResultList]  # { id: sd for (scan['ID'], scan['series_description']) in scanRequestResultList }
     _logger.debug('Found scans %s.' % ', '.join(scanIDList))
     _logger.debug('Series descriptions %s' % ', '.join(seriesDescList))
-
-    # Fall back on scan type if series description field is empty
-    if set(seriesDescList) == set(['']):
-        seriesDescList = [scan['type'] for scan in scanRequestResultList]
-        _logger.debug('Fell back to scan types %s' % ', '.join(seriesDescList))
     _logger.info("------------------------------------------------")
 
     return scanIDList, seriesDescList


### PR DESCRIPTION
Before, the `seqlist` parameter would often give the right sequence, but on some datasets the sequence would be all wrong. XNAT does not sort the `/data/experiments/{experiment_id}/scan` results. Using the XNAT `sortBy` query string sorts in alpha order, not numeric order. I added the sort in the python code to compensate for the bad `sortBy` parameter, and added a test to verify the fix.