### PR TITLE
ci: Add a workflow for manual rebuild of docs

### DIFF
--- a/.github/workflows/dev-docs.yml
+++ b/.github/workflows/dev-docs.yml
@@ -18,7 +18,7 @@ jobs:
         run: | 
           python -m pip install --upgrade pip 
           pip install .
-          pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning
+          pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning mkdocs-markdownextradata-plugin
           pip install typer-cli
       - name: Set up mkdocs config
         run: | 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       run: | 
         python -m pip install --upgrade pip 
         pip install .
-        pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning
+        pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning mkdocs-markdownextradata-plugin
     - name: Set up mkdocs config 
       run: (envsubst 'v${VERSION}' < mkdocs-template.yml) > mkdocs.yml
     - name: Sync 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         echo ::set-env name=VERSION::$(cat pyproject.toml | grep version | head -1 | awk -F: '{ print $1 }'| sed 's/[\",]//g'| tr -d 'version = ')
         echo "VERSION: $VERSION"
     - name: Copy CHANGELOG to docs and push to remote
+      id: commit
       run: |
         cp CHANGELOG.md docs/changelog.md
 
@@ -31,11 +32,9 @@ jobs:
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         git add -A
-        git commit -m "docs: Update docs/changelog.md" || echo "No changes to commit"
-        git push || echo "No changes to push"
+        git commit -m "docs: Update docs/changelog.md"
+        git push
     - name: Release to GitHub
-      id: release
-      continue-on-error: true
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/replace-docs.yml
+++ b/.github/workflows/replace-docs.yml
@@ -1,0 +1,37 @@
+name: replace docs 
+on: [workflow_dispatch]
+jobs: 
+  replace-docs:
+    runs-on: ubuntu-latest
+    name: 'Rebuilds and publish the latest docs'
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Store VERSION
+      run: |
+        echo ::set-env name=VERSION::$(cat pyproject.toml | grep version | head -1 | awk -F: '{ print $1 }'| sed 's/[\",]//g'| tr -d 'version = ')
+        echo "VERSION: $VERSION"
+    - name: Set up Python 3.7 
+      uses: actions/setup-python@v2 
+      with: 
+        python-version: '3.7.5' 
+    - name: Install dependencies 
+      run: | 
+        python -m pip install --upgrade pip 
+        pip install .
+        pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning
+    - name: Set up mkdocs config 
+      run: (envsubst 'v${VERSION}' < mkdocs-template.yml) > mkdocs.yml
+    - name: Sync 
+      run: | 
+        git pull
+        mkdir site
+        mkdocs-versioning sync
+        rm -rf ./site/${VERSION}
+        rm -rf ./site/.git/
+    - name: Build
+      run: mkdocs build
+    - name: Deploy
+      run: mkdocs-versioning -v deploy

--- a/.github/workflows/replace-docs.yml
+++ b/.github/workflows/replace-docs.yml
@@ -21,7 +21,7 @@ jobs:
       run: | 
         python -m pip install --upgrade pip 
         pip install .
-        pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning
+        pip install mkdocs mkdocs-material mkdocstrings mkdocs-versioning mkdocs-markdownextradata-plugin
     - name: Set up mkdocs config 
       run: (envsubst 'v${VERSION}' < mkdocs-template.yml) > mkdocs.yml
     - name: Sync 

--- a/docs/dicom_export.md
+++ b/docs/dicom_export.md
@@ -22,7 +22,7 @@ $ xnat-dicom-export [OPTIONS] SESSION BIDS_ROOT_DIR
 * `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names  [default: ]
 * `-i, --includeseq INTEGER`: Include this sequence only, can specify multiple times  [default: ]
 * `-s, --skipseq INTEGER`: Exclude this sequence, can specify multiple times  [default: ]
-* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-00-56]
+* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-27-27]
 * `-v, --verbose`: Verbose level. Can be specified multiple times to increase verbosity  [default: 0]
 * `--overwrite`: Remove directories where prior results for session/participant may exist  [default: False]
 * `--install-completion`: Install completion for the current shell.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,10 +15,41 @@ You can confirm the tags [here](https://hub.docker.com/repository/docker/brownbn
 
 ### Prerequisites:
 
-We first need to install the dcm2niix . This is a dependency of Heudiconv, that doesn't get installed by Heudiconv itself
+We first need to install the dcm2niix . This is a dependency of Heudiconv that doesn't get installed by Heudiconv itself
 
 ```
 brew install dcm2niix
+```
+
+### PIPX
+
+Most users only need to interact with the command-line utilities provided by `xnat-tools`. In this case, we recommend using `pipx`. Please check their [installation instructions](https://github.com/pipxproject/pipx).
+
+Once `pipx` is installed you will need to install Heudiconv and xnat-tools as stand-alone applications as follows:
+
+```
+pipx install heudiconv
+pipx install git+https://github.com/brown-bnc/xnat-tools.git@v{{ mdvars.version }}
+```
+
+The command above installs the latest tagged release of `xnat-tools`. If you want to install the development version (main branch) you can run:
+
+```
+pipx install git+https://github.com/brown-bnc/xnat-tools.git
+```
+
+### PIP
+
+- A Tagged Release
+
+```
+pip install git+https://github.com/brown-bnc/xnat-tools.git@v{{ mdvars.version }}
+```
+
+- Development (Master branch)
+
+```
+pip install git+https://github.com/brown-bnc/xnat-tools.git
 ```
 
 ### Poetry
@@ -32,40 +63,6 @@ poetry add git+https://github.com/brown-bnc/xnat-tools.git
 or for a tagged release
 
 ```
-poetry add git+https://github.com/brown-bnc/xnat-tools.git@v0.1.0
-```
-
-You can also install xnat_tools using the python package manager of your choice, such as PIPX and PIP
-
-### PIPX
-
-If you are using this package in a stand-alone fashion, and you don't want to use Docker, we recommend using pipx. Please check their [installation instructions](https://github.com/pipxproject/pipx).
-
-Once pipx is installed you install as follows:
-
-A Tagged Release
-
-```
-pipx install git+https://github.com/brown-bnc/xnat-tools.git@v0.1.0
-```
-
-Development (Master branch)
-
-```
-pipx install git+https://github.com/brown-bnc/xnat-tools.git
-```
-
-### PIP
-
-- A Tagged Release
-
-```
-pip install git+https://github.com/brown-bnc/xnat-tools.git@v0.1.0
-```
-
-- Development (Master branch)
-
-```
-pip install git+https://github.com/brown-bnc/xnat-tools.git
+poetry add git+https://github.com/brown-bnc/xnat-tools.git@v{{ mdvars.version }}
 ```
 

--- a/docs/run_heudiconv.md
+++ b/docs/run_heudiconv.md
@@ -18,7 +18,7 @@ $ xnat-heudiconv [OPTIONS] PROJECT SUBJECT SESSION BIDS_ROOT_DIR
 **Options**:
 
 * `-S, --session-suffix TEXT`: Suffix of the session for BIDS defaults to 01.              This will produce a session label of sess-01.              You likely only need to change the default for multi-session studies  [default: 01]
-* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-00-57]
+* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-27-27]
 * `--overwrite / --no-overwrite`: Remove directories where prior results for session/participant may exist  [default: False]
 * `--cleanup / --no-cleanup`: Remove xnat-export folder and move logs to derivatives/xnat/logs  [default: False]
 * `--install-completion`: Install completion for the current shell.

--- a/docs/xnat2bids.md
+++ b/docs/xnat2bids.md
@@ -22,7 +22,7 @@ $ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
 * `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names  [default: ]
 * `-i, --includeseq INTEGER`: Include this sequence only, can specify multiple times  [default: ]
 * `-s, --skipseq INTEGER`: Exclude this sequence, can be specified multiple times  [default: ]
-* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-00-56]
+* `--log-id TEXT`: ID or suffix to append to logfile, If empty, date is appended  [default: 10-27-2020-21-27-27]
 * `-v, --verbose`: Verbose level. Can be specified multiple times to increase verbosity  [default: 0]
 * `--overwrite`: Remove directories where prior results for this session/participant  [default: False]
 * `--cleanup / --no-cleanup`: Remove xnat-export folder and move logs to derivatives/xnat/logs  [default: False]

--- a/mkdocs-template.yml
+++ b/mkdocs-template.yml
@@ -18,6 +18,7 @@ edit_uri: ''
 
 plugins:
   - search
+  - markdownextradata
   - mkdocs-versioning:
       version: ${VERSION}
       version_selection_page: "docs/version_selection.md"
@@ -44,8 +45,9 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github-alt
-      link: 'https://github.com/brown-bnc/xnat-tools'
-
+      link: 'https://github.com/brown-bnc/xnat-tools' 
+  mdvars:
+    version: ${VERSION}
 nav:
   - Getting Started:
     - Overview: index.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -441,6 +441,18 @@ version = "0.5.8"
 
 [[package]]
 category = "dev"
+description = "A MkDocs plugin that injects the mkdocs.yml extra variables into the markdown template"
+name = "mkdocs-markdownextradata-plugin"
+optional = false
+python-versions = ">=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "0.1.7"
+
+[package.dependencies]
+mkdocs = "*"
+pyyaml = "*"
+
+[[package]]
+category = "dev"
 description = "A Material Design theme for MkDocs"
 name = "mkdocs-material"
 optional = false
@@ -1191,7 +1203,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "dd37a5b20b837f2ab2c624c915b3bb08a22fec17e71e21f727f0ca2f751e1b22"
+content-hash = "789bfd0fa332ace8aa811a316eaa27a9f04d66b2bfae4c75b41b5de36395c449"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1395,6 +1407,10 @@ mccabe = [
 mkdocs = [
     {file = "mkdocs-1.1.2-py3-none-any.whl", hash = "sha256:096f52ff52c02c7e90332d2e53da862fde5c062086e1b5356a6e392d5d60f5e9"},
     {file = "mkdocs-1.1.2.tar.gz", hash = "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"},
+]
+mkdocs-markdownextradata-plugin = [
+    {file = "mkdocs-markdownextradata-plugin-0.1.7.tar.gz", hash = "sha256:243428c30cb062499b02676c39649b03d3ffe09b141cba9148e571d8f80f5dd6"},
+    {file = "mkdocs_markdownextradata_plugin-0.1.7-py3-none-any.whl", hash = "sha256:761f2fb15249bcfbb7ac30269bf50700a3ffbd5b96c16608874f87dd1c09fab5"},
 ]
 mkdocs-material = [
     {file = "mkdocs-material-6.1.0.tar.gz", hash = "sha256:a4bfd736898e6bfeb2c0d00ab448f464a389fb6a7dd2a30a90343756fd8aec83"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ mypy = "^0.782"
 mkdocs-versioning = "^0.3.0"
 Commitizen = "^2.4.1"
 pre-commit = "^2.7.1"
+mkdocs-markdownextradata-plugin = "^0.1.7"
 
 [tool.poetry.scripts]
 bids-postprocess ="xnat_tools.bids_postprocess:main"


### PR DESCRIPTION
This is because by default `MkDocs` doesn't replace a current version. This is to be used when the version of the package is not bumped, but we want to update the docs