### PR TITLE
Feat inherit eeg bids keys

### DIFF
--- a/xnat_tools/dcm2bids.py
+++ b/xnat_tools/dcm2bids.py
@@ -1,3 +1,4 @@
+import glob
 import os
 from datetime import datetime
 
@@ -44,21 +45,47 @@ def dcm2bids(
     ),
 ):
 
-    r = run_heudiconv(
-        project,
-        subject,
-        bids_root_dir,
-        session_suffix=session_suffix,
-        log_id=log_id,
-        overwrite=overwrite,
-        cleanup=cleanup,
-    )
-
     pi_prefix, study_prefix, subject_prefix, session_prefix = prepare_path_prefixes(
         project, subject, session
     )
 
     bids_experiment_dir = f"{bids_root_dir}/{pi_prefix}/{study_prefix}/bids"
+
+    # Build path to exported data
+    xnat_data_path = (
+        f"{bids_root_dir}/{pi_prefix}/{study_prefix}/xnat-export/"
+        f"{subject_prefix}/ses-{session_suffix}/"
+    )
+
+    # Build path to exported eeg data
+    eeg_data_path = f"{xnat_data_path}/eeg/"
+    eeg_data = os.path.isdir(eeg_data_path)
+
+    if len(glob.glob(xnat_data_path + "/*/*.dcm")) == 0:
+        # if we have no DICOMs, allow it as long as there is an eeg directory
+        if eeg_data:
+            r = True
+        else:
+            raise RuntimeError("No DICOM files found to convert to BIDS format")
+    else:
+        r = run_heudiconv(
+            project,
+            subject,
+            bids_root_dir,
+            session_suffix=session_suffix,
+            log_id=log_id,
+            overwrite=overwrite,
+            cleanup=cleanup,
+        )
+
+    # Convert EEG data to BIDS if present
+    if eeg_data:
+        run_mne_eeg2bids(
+            subject,
+            session_suffix,
+            bids_experiment_dir,
+            eeg_data_path,
+        )
 
     bids_postprocess(
         bids_experiment_dir,
@@ -73,21 +100,5 @@ def dcm2bids(
         verbose=0,
         overwrite=False,
     )
-
-    # Build path to exported eeg data
-    eeg_data_path = (
-        f"{bids_root_dir}/{pi_prefix}/{study_prefix}/xnat-export/"
-        f"{subject_prefix}/ses-{session_suffix}/eeg/"
-    )
-
-    # Convert EEG data to BIDS if present
-    if os.path.isdir(eeg_data_path):
-
-        run_mne_eeg2bids(
-            subject,
-            session_suffix,
-            bids_experiment_dir,
-            eeg_data_path,
-        )
 
     return r


### PR DESCRIPTION
Modified run_mne_eeg2bids to process multiple EEG files uploaded to a single session, and to follow similar "BIDS-friendly" naming principles as for MR data to extract BIDS key-value pairs from EEG filenames and use them in BIDS file naming.

Now EEG data named like this when exported from XNAT:
![Screenshot 2023-10-13 at 10 02 47 AM](https://github.com/brown-bnc/xnat-tools/assets/3599097/3a143d6e-83de-4e0d-a9d0-99c14ab9fc07)

is converted to BIDS format like this:
![Screenshot 2023-10-13 at 10 02 56 AM](https://github.com/brown-bnc/xnat-tools/assets/3599097/ae93bb4e-ab04-4213-afed-7871183cf5ce)
