### PR TITLE
fix: extract session number when underscore in subID

### DIFF
--- a/xnat_tools/xnat_utils.py
+++ b/xnat_tools/xnat_utils.py
@@ -64,18 +64,8 @@ def get_project_subject_session(connection, host, session, session_suffix):
     project = sessionValuesJson["project"]
     subjectID = sessionValuesJson["subject_ID"]
 
-    # If session_suffix == -1, the user has not specified a session value.
-    # Fetch session data from XNAT label (formatted: subj_sess) if exists.
-    # Otherwise, set session label to '01' by default.
-    if session_suffix == "-1":
-        if len(sessionValuesJson["label"].split("_")) == 2:
-            session_suffix = sessionValuesJson["label"].split("_")[1]
-        else:
-            session_suffix = "01"
-
     print("Project: " + project)
     print("Subject ID: " + subjectID)
-    print("Session Suffix:  " + session_suffix)
     r = get(
         connection,
         host + "/data/subjects/%s" % subjectID,
@@ -83,6 +73,19 @@ def get_project_subject_session(connection, host, session, session_suffix):
     )
     subject = r.json()["ResultSet"]["Result"][0]["label"]
     print("Subject label: " + subject)
+
+    # If session_suffix == -1, the user has not specified a session value.
+    # Fetch session data from XNAT label (formatted: subj_sess) if exists.
+    # Otherwise, set session label to '01' by default.
+    if session_suffix == "-1":
+        if (len(sessionValuesJson["label"].split("_")) > 1) and (
+            (subject + "_") in sessionValuesJson["label"]
+        ):
+            session_suffix = sessionValuesJson["label"].split(subject + "_")[-1]
+        else:
+            session_suffix = "01"
+    print("Session Suffix:  " + session_suffix)
+
     print("------------------------------------------------")
 
     return project, subject, session_suffix


### PR DESCRIPTION
Previously, if the subject ID contained an underscore, extracting the session label from the end would fail because the code expected only a single underscore in subj_sess. Since the path_string_preprocess function in bids_utils.py appropriately removes underscores from subject IDs, it makes sense to also handle them correctly here. Now, if the label contains the same string as the subject ID, "subjectID_" is removed, and the remainder is taken as the session label.