### PR TITLE
fix(dicom_export.py): validate frame counts of all acquisitons 

### DIFF
--- a/docs/dicom_export.md
+++ b/docs/dicom_export.md
@@ -25,7 +25,7 @@ $ dicom_export [OPTIONS] SESSION BIDS_ROOT_DIR
 * `--log-id TEXT`: ID or suffix to append to logfile. If empty, current date is used  [default: current date - MM-DD-YYYY-HH-MM-SS]
 * `-v, --verbose`: Verbose level. Can be specified multiple times to increase verbosity  [default: 0]
 * `--overwrite`: Remove directories where prior results for session/participant may exist
-* `--validate_frames`: Validate the frame counts of all acquisitons of bold sequences.
+* `--validate_frames`: Validate frame counts for all BOLD sequence acquisitions. Deletes the DICOM file if the final acquisition lacks expected slices.
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/xnat2bids.md
+++ b/docs/xnat2bids.md
@@ -28,7 +28,7 @@ $ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
 * `--cleanup`: Remove xnat-export folder and move logs to derivatives/xnat/logs
 * `--skip-export`: Skip DICOM Export, while only running BIDS conversion
 * `--export-only`: Run DICOM Export without subsequent BIDS conversion
-* `--validate_frames`: Validate the frame counts of all acquisitons of provided task types.
+* `--validate_frames`: Validate the frame counts of all acquisitions of functional bold sequences. If the final acquisition does not contain the expected number of slices, the associated DICOM file will be deleted.
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/tests/integration/test_export_and_heudiconv.py
+++ b/tests/integration/test_export_and_heudiconv.py
@@ -53,6 +53,7 @@ def test_dicom_export():
         log_id="pytest",
         verbose=0,
         overwrite=False,
+        validate_frames=False,
     )
 
     assert p == project

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -573,22 +573,6 @@ def assign_bids_name(
         _logger.info("---------------------------------")
 
 
-def validate_frame_count(dicomFileList):
-    firstAcquisition = dicomFileList[0][0]
-    lastAcquisition = dicomFileList[-1][0]
-
-    firstAcqFrameCount = pydicom.dcmread(firstAcquisition)[0x0028, 0x0008].value
-    lastAcqFrameCount = pydicom.dcmread(lastAcquisition)[0x0028, 0x0008].value
-
-    if firstAcqFrameCount != lastAcqFrameCount:
-        if os.path.exists(lastAcquisition):
-            os.remove(lastAcquisition)
-            print("REMOVING LAST ACQUISITION: ", lastAcquisition)
-    #    if os.path.exists(firstAcquisition):
-    #         os.remove(firstAcquisition)
-    #         print("REMOVING ACQUISITION", firstAcquisition)
-
-
 def run_mne_eeg2bids(
     subject,
     session_suffix,

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -453,10 +453,10 @@ def read_dicom_frame_count(file_path: str) -> int:
     return dicom.get((0x0028, 0x0008), None)
 
 
-def validate_frame_counts(scans: list, task_type: str, bids_session_dir: str) -> None:
+def validate_frame_counts(scans: list, bids_session_dir: str) -> None:
 
     for _, series_desc in scans:
-        if f"task-{task_type}" in series_desc:
+        if "func" in series_desc:
             bids_scan_dir = os.path.join(bids_session_dir, series_desc)
 
             with os.scandir(bids_scan_dir) as entries:

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -482,6 +482,9 @@ def validate_frame_counts(scans: list, bids_session_dir: str) -> None:
                     last_file_path = os.path.join(bids_scan_dir, dicom_files[-1])
 
                     if os.path.exists(last_file_path):
+                        _logger.info(
+                            f"Detected discrepant frame counts. Removing DICOM: {last_file_path}"
+                        )
                         os.remove(last_file_path)
 
 

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -92,7 +92,10 @@ def dicom_export(
     validate_frames: bool = typer.Option(
         False,
         "--validate_frames",
-        help="Validate the frame counts of all acquisitons of bold sequences.",
+        help=(
+            "Validate frame counts for all BOLD sequence acquisitions. "
+            "Deletes the DICOM file if the final acquisition lacks expected slices."
+        ),
     ),
 ):
 

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -89,10 +89,10 @@ def dicom_export(
         "--overwrite",
         help="Remove directories where prior results for session/participant may exist",
     ),
-    validate_frames: List[str] = typer.Option(
-        [],
+    validate_frames: bool = typer.Option(
+        False,
         "--validate_frames",
-        help="Validate the frame counts of all acquisitons of provided task types.",
+        help="Validate the frame counts of all acquisitons of bold sequences.",
     ),
 ):
 
@@ -158,8 +158,8 @@ def dicom_export(
         export_session_dir,
     )
 
-    for task_type in validate_frames:
-        validate_frame_counts(scans, task_type, export_session_dir)
+    if validate_frames:
+        validate_frame_counts(scans, export_session_dir)
 
     # Close connection(I don't think this works)
     connection.delete(f"{host}/data/JSESSION")

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -25,6 +25,7 @@ from xnat_tools.bids_utils import (
     path_string_preprocess,
     prepare_export_output_path,
     prepare_path_prefixes,
+    validate_frame_counts,
 )
 from xnat_tools.logging import setup_logging
 from xnat_tools.xnat_utils import (
@@ -87,6 +88,11 @@ def dicom_export(
         False,
         "--overwrite",
         help="Remove directories where prior results for session/participant may exist",
+    ),
+    validate_frames: List[str] = typer.Option(
+        [],
+        "--validate_frames",
+        help="Validate the frame counts of all acquisitons of provided task types.",
     ),
 ):
 
@@ -151,6 +157,9 @@ def dicom_export(
         build_dir,
         export_session_dir,
     )
+
+    for task_type in validate_frames:
+        validate_frame_counts(scans, task_type, export_session_dir)
 
     # Close connection(I don't think this works)
     connection.delete(f"{host}/data/JSESSION")

--- a/xnat_tools/xnat2bids.py
+++ b/xnat_tools/xnat2bids.py
@@ -77,6 +77,11 @@ def xnat2bids(
         "--export-only",
         help="Run DICOM Export without subsequent BIDS conversion",
     ),
+    validate_frames: List[str] = typer.Option(
+        [],
+        "--validate_frames",
+        help="Validate the frame counts of all acquisitons of provided task types.",
+    ),
 ):
     """
     Export DICOM images from an XNAT experiment to a BIDS compliant directory
@@ -97,6 +102,7 @@ def xnat2bids(
             log_id=log_id,
             verbose=verbose,
             overwrite=overwrite,
+            validate_frames=validate_frames,
         )
 
     if not export_only:

--- a/xnat_tools/xnat2bids.py
+++ b/xnat_tools/xnat2bids.py
@@ -80,7 +80,11 @@ def xnat2bids(
     validate_frames: bool = typer.Option(
         False,
         "--validate_frames",
-        help="Validate the frame counts of all acquisitons of provided task types.",
+        help=(
+            "Validate the frame counts of all acquisitions of functional bold sequences. "
+            "If the final acquisition does not contain the expected number of slices, "
+            "the associated DICOM file will be deleted."
+        ),
     ),
 ):
     """

--- a/xnat_tools/xnat2bids.py
+++ b/xnat_tools/xnat2bids.py
@@ -77,8 +77,8 @@ def xnat2bids(
         "--export-only",
         help="Run DICOM Export without subsequent BIDS conversion",
     ),
-    validate_frames: List[str] = typer.Option(
-        [],
+    validate_frames: bool = typer.Option(
+        False,
         "--validate_frames",
         help="Validate the frame counts of all acquisitons of provided task types.",
     ),


### PR DESCRIPTION
## Validate Frame Counts of Acquisitions

## New Flag!  --validate_frames
Users can now pass a `--validate_frames ` to the xnat2bids pipeline.  By default, validate_frames will be set to false if not provided.  

After exporting all the dicoms, the pipeline loops through all functional scans, comparing the frame count of the first and final acquisitions.  If there is a discrepancy, the last dicom is remove from the filesystem.  