### PR TITLE
fix: remove all echoes if partial DICOM is found

### DIFF
--- a/docs/dicom_export.md
+++ b/docs/dicom_export.md
@@ -17,7 +17,7 @@ $ dicom_export [OPTIONS] SESSION BIDS_ROOT_DIR
 
 * `-u, --user TEXT`: XNAT User
 * `-p, --pass TEXT`: XNAT Password
-* `-h, --host TEXT`: XNAT's URL  [default: https://xnat.bnc.brown.edu]
+* `-h, --host TEXT`: XNAT&#x27;s URL  [default: https://xnat.bnc.brown.edu]
 * `-S, --session-suffix TEXT`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
 * `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names
 * `-i, --includeseq TEXT`: Include this sequence only, this flag can specify multiple times

--- a/docs/run_heudiconv.md
+++ b/docs/run_heudiconv.md
@@ -10,8 +10,8 @@ $ run_heudiconv [OPTIONS] PROJECT SUBJECT BIDS_ROOT_DIR
 
 **Arguments**:
 
-* `PROJECT`: XNAT's Project ID  [required]
-* `SUBJECT`: XNAT's subject ID  [required]
+* `PROJECT`: XNAT&#x27;s Project ID  [required]
+* `SUBJECT`: XNAT&#x27;s subject ID  [required]
 * `BIDS_ROOT_DIR`: Root output directory for exporting files  [required]
 
 **Options**:

--- a/docs/xnat2bids.md
+++ b/docs/xnat2bids.md
@@ -17,7 +17,7 @@ $ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
 
 * `-u, --user TEXT`: XNAT User
 * `-p, --pass TEXT`: XNAT Password
-* `-h, --host TEXT`: XNAT'sURL  [default: https://xnat.bnc.brown.edu]
+* `-h, --host TEXT`: XNAT&#x27;sURL  [default: https://xnat.bnc.brown.edu]
 * `-S, --session-suffix TEXT`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
 * `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names
 * `-i, --includeseq TEXT`: Include this sequence only, this flag can specify multiple times
@@ -29,6 +29,7 @@ $ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
 * `--skip-export`: Skip DICOM Export, while only running BIDS conversion
 * `--export-only`: Run DICOM Export without subsequent BIDS conversion
 * `--validate_frames`: Validate the frame counts of all acquisitions of functional bold sequences. If the final acquisition does not contain the expected number of slices, the associated DICOM file will be deleted.
+* `-d, --dicomfix-config TEXT`: JSON file to correct DICOM fields. USE WITH CAUTION
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.


### PR DESCRIPTION
Previously, the validate_frame_counts function checked whether every DICOM in a functional run had the same number of frames (slices) as the first DICOM. A partial DICOM can result from a run being manually terminated at the scanner. This created valid BIDS data for both single- and multi-echo data, but for multi-echo data could result in unequal numbers of volumes across echoes. This fix makes sure to remove all echoes from a volume if any of the echoes yielded a partial DICOM.