### PR TITLE
add units field for anatomical scans

### DIFF
--- a/xnat_tools/bids_postprocess.py
+++ b/xnat_tools/bids_postprocess.py
@@ -5,6 +5,7 @@ from typing import List
 import typer
 
 from xnat_tools.bids_utils import (
+    append_anat_units_field,
     insert_intended_for_fmap,
     path_string_preprocess,
     remove_func_acquisition_duration_field,
@@ -109,6 +110,13 @@ def bids_postprocess(
             includesess,
         )
 
+        append_anat_units_field(
+            bids_experiment_dir,
+            includesubj,
+            session_suffix,
+            includesess,
+        )
+
     else:
         if includesubj == []:
             files = os.listdir(bids_experiment_dir)
@@ -155,6 +163,13 @@ def bids_postprocess(
         )
 
         remove_func_acquisition_duration_field(
+            bids_experiment_dir,
+            includesubj,
+            session,
+            includesess,
+        )
+
+        append_anat_units_field(
             bids_experiment_dir,
             includesubj,
             session,

--- a/xnat_tools/bids_postprocess.py
+++ b/xnat_tools/bids_postprocess.py
@@ -5,7 +5,7 @@ from typing import List
 import typer
 
 from xnat_tools.bids_utils import (
-    append_anat_units_field,
+    append_phase_units_field,
     insert_intended_for_fmap,
     path_string_preprocess,
     remove_func_acquisition_duration_field,
@@ -110,7 +110,7 @@ def bids_postprocess(
             includesess,
         )
 
-        append_anat_units_field(
+        append_phase_units_field(
             bids_experiment_dir,
             includesubj,
             session_suffix,
@@ -169,7 +169,7 @@ def bids_postprocess(
             includesess,
         )
 
-        append_anat_units_field(
+        append_phase_units_field(
             bids_experiment_dir,
             includesubj,
             session,

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -101,8 +101,6 @@ def build_sessions_list(bids_dir, subj, session="", sess_list=None):
     subj_path = f"{bids_dir}/sub-{subj}"
     subj_sub_dirs = os.listdir(subj_path)
 
-    log_info(f"Processing participant {subj} at path {subj_path}")
-
     # If a session is provided, only process that session.
     # If the includesess list is not empty, cocatenate all session
     # suffixes with "ses-" prefix for the file path.
@@ -128,19 +126,25 @@ def ensure_json_field(json_path, field, default):
 
             with open(json_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=4)
-            _logger.info(f"Added {field} field to {json_path}")
+            log_info(f"Added {field} field to {json_path}")
         else:
-            _logger.info(f"{field} field already present in {json_path}")
+            log_info(f"{field} field already present in {json_path}")
     except Exception as e:
-        _logger.info(f"Error processing {json_path}: {e}")
+        log_info(f"Error processing {json_path}: {e}")
 
 
 def append_phase_units_field(bids_dir, sub_list=None, session="", sess_list=None):
     for subj in sub_list:
-        for sess in sess_list:
-            ses_dir = os.path.join(bids_dir, f"sub-{subj}", f"ses-{sess}")
+
+        # makes list of the sessions to process
+        sessions = build_sessions_list(bids_dir, subj, session, sess_list)
+
+        for sess in sessions:
+            ses_dir = os.path.join(bids_dir, f"sub-{subj}", f"{sess}")
             if not os.path.isdir(ses_dir):
                 continue
+
+            log_info(f"Checking for missing phase units in jsons at path {ses_dir}")
 
             # Walk through all folders under the session directory (anat, func, etc.)
             for root, _, files in os.walk(ses_dir):
@@ -167,11 +171,14 @@ def remove_func_acquisition_duration_field(bids_dir, sub_list=None, session="", 
         _logger.info(f"List of sessions sub-directories {sessions}")
 
         for sess in sessions:
+
             func_path = f"{bids_dir}/sub-{subj}/{sess}/func"
 
             # Don't do anything if this session doesn't contain a func folder
             if not os.path.exists(func_path):
                 continue
+
+            log_info(f"Removing AcquisitionDuration field from jsons at path {func_path}")
 
             func_jsons = [
                 os.path.join(func_path, f) for f in os.listdir(func_path) if f.endswith("json")

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -118,7 +118,7 @@ def build_sessions_list(bids_dir, subj, session="", sess_list=None):
 
 
 def ensure_json_field(json_path, field, default):
-    """Add 'Units' key with empty value if missing from JSON."""
+    """Add 'Units' key with default value if missing from JSON."""
     try:
         with open(json_path, "r", encoding="utf-8") as f:
             data = json.load(f)


### PR DESCRIPTION
## Appends "Units" Field to Anatomical Scans 

The required units values, according to the validator, is "rad" or "arbitrary".  I chose the latter, but this can be changed if needed.  

Q.  Is it correct behavior to append the "Units" field to all anatomical scans? If this is only needed for ME-GRE, we could only apply the change to those files.  This would require us to ensure scans are properly named at the scanner, ending in MERGE. 

The following BIDS Validator 2.0 error for scan XNAT_E00676 was resolved with these changes:

```
	[ERROR] SIDECAR_KEY_REQUIRED A data file's JSON sidecar is missing a key listed as required.
		Units
```