### PR TITLE
feat export refaced

### DIFF
--- a/docs/dicom_export.md
+++ b/docs/dicom_export.md
@@ -27,6 +27,7 @@ $ dicom_export [OPTIONS] SESSION BIDS_ROOT_DIR
 * `--overwrite`: Remove directories where prior results for session/participant may exist
 * `--validate_frames`: Validate frame counts for all BOLD sequence acquisitions. Deletes the DICOM file if the final acquisition lacks expected slices.
 * `-d, --dicomfix-config TEXT`: JSON file to correct DICOM fields. USE WITH CAUTION
+* `--export-refaced`: Prefer REFACED_DICOM where available; otherwise export standard DICOM
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/dicom_export.md
+++ b/docs/dicom_export.md
@@ -5,29 +5,29 @@ Export XNAT DICOM images in an experiment to a BIDS friendly format
 **Usage**:
 
 ```console
-$ dicom_export [OPTIONS] SESSION BIDS_ROOT_DIR
+$ dicom_export [OPTIONS] {session} {bids_root_dir}
 ```
 
 **Arguments**:
 
-* `SESSION`: XNAT Session ID, that is the Accession # for an experiment.  [required]
-* `BIDS_ROOT_DIR`: Root output directory for exporting the files  [required]
+* `session`: XNAT Session ID, that is the Accession # for an experiment.  [required]
+* `bids_root_dir`: Root output directory for exporting the files  [required]
 
 **Options**:
 
-* `-u, --user TEXT`: XNAT User
-* `-p, --pass TEXT`: XNAT Password
-* `-h, --host TEXT`: XNAT&#x27;s URL  [default: https://xnat.bnc.brown.edu]
-* `-S, --session-suffix TEXT`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
-* `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names
-* `-i, --includeseq TEXT`: Include this sequence only, this flag can specify multiple times
-* `-s, --skipseq TEXT`: Exclude this sequence, this flag can specify multiple times
-* `--log-id TEXT`: ID or suffix to append to logfile. If empty, current date is used  [default: current date - MM-DD-YYYY-HH-MM-SS]
+* `-u, --user <str>`: XNAT User
+* `-p, --pass <str>`: XNAT Password
+* `-h, --host <str>`: XNAT&#x27;s URL  [default: https://xnat.bnc.brown.edu]
+* `-S, --session-suffix <str>`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
+* `-f, --bidsmap-file <str>`: Bidsmap JSON file to correct sequence names
+* `-i, --includeseq <str>`: Include this sequence only, this flag can specify multiple times
+* `-s, --skipseq <str>`: Exclude this sequence, this flag can specify multiple times
+* `--log-id <str>`: ID or suffix to append to logfile. If empty, current date is used  [default: current date - MM-DD-YYYY-HH-MM-SS]
 * `-v, --verbose`: Verbose level. Can be specified multiple times to increase verbosity  [default: 0]
 * `--overwrite`: Remove directories where prior results for session/participant may exist
 * `--validate_frames`: Validate frame counts for all BOLD sequence acquisitions. Deletes the DICOM file if the final acquisition lacks expected slices.
-* `-d, --dicomfix-config TEXT`: JSON file to correct DICOM fields. USE WITH CAUTION
-* `--export-refaced`: Prefer REFACED_DICOM where available; otherwise export standard DICOM
+* `-d, --dicomfix-config <str>`: JSON file to correct DICOM fields. USE WITH CAUTION
+* `--force-non-defaced`: Export original DICOM when REFACED_DICOM is available
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/xnat2bids.md
+++ b/docs/xnat2bids.md
@@ -30,6 +30,7 @@ $ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
 * `--export-only`: Run DICOM Export without subsequent BIDS conversion
 * `--validate_frames`: Validate the frame counts of all acquisitions of functional bold sequences. If the final acquisition does not contain the expected number of slices, the associated DICOM file will be deleted.
 * `-d, --dicomfix-config TEXT`: JSON file to correct DICOM fields. USE WITH CAUTION
+* `--export-refaced`: Prefer REFACED_DICOM where available; otherwise export standard DICOM
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/xnat2bids.md
+++ b/docs/xnat2bids.md
@@ -5,32 +5,32 @@ Export DICOM images from an XNAT experiment to a BIDS compliant directory
 **Usage**:
 
 ```console
-$ xnat2bids [OPTIONS] SESSION BIDS_ROOT_DIR
+$ xnat2bids [OPTIONS] {session} {bids_root_dir}
 ```
 
 **Arguments**:
 
-* `SESSION`: XNAT Session ID, that is the Accession # for an experiment.  [required]
-* `BIDS_ROOT_DIR`: Root output directory for exporting the files  [required]
+* `session`: XNAT Session ID, that is the Accession # for an experiment.  [required]
+* `bids_root_dir`: Root output directory for exporting the files  [required]
 
 **Options**:
 
-* `-u, --user TEXT`: XNAT User
-* `-p, --pass TEXT`: XNAT Password
-* `-h, --host TEXT`: XNAT&#x27;sURL  [default: https://xnat.bnc.brown.edu]
-* `-S, --session-suffix TEXT`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
-* `-f, --bidsmap-file TEXT`: Bidsmap JSON file to correct sequence names
-* `-i, --includeseq TEXT`: Include this sequence only, this flag can specify multiple times
-* `-s, --skipseq TEXT`: Exclude this sequence, can be specified multiple times
-* `--log-id TEXT`: ID or suffix to append to logfile. If empty, current date is used  [default: current date - MM-DD-YYYY-HH-MM-SS]
+* `-u, --user <str>`: XNAT User
+* `-p, --pass <str>`: XNAT Password
+* `-h, --host <str>`: XNAT&#x27;sURL  [default: https://xnat.bnc.brown.edu]
+* `-S, --session-suffix <str>`: The session_suffix is initially set to -1.              This will signify an unspecified session_suffix and default to sess-01.              For multi-session studies, the session label will be pulled from XNAT  [default: -1]
+* `-f, --bidsmap-file <str>`: Bidsmap JSON file to correct sequence names
+* `-i, --includeseq <str>`: Include this sequence only, this flag can specify multiple times
+* `-s, --skipseq <str>`: Exclude this sequence, can be specified multiple times
+* `--log-id <str>`: ID or suffix to append to logfile. If empty, current date is used  [default: current date - MM-DD-YYYY-HH-MM-SS]
 * `-v, --verbose`: Verbose level. This flag can be specified multiple times to increase verbosity  [default: 0]
 * `--overwrite`: Remove directories where prior results for this session/participant
 * `--cleanup`: Remove xnat-export folder and move logs to derivatives/xnat/logs
 * `--skip-export`: Skip DICOM Export, while only running BIDS conversion
 * `--export-only`: Run DICOM Export without subsequent BIDS conversion
 * `--validate_frames`: Validate the frame counts of all acquisitions of functional bold sequences. If the final acquisition does not contain the expected number of slices, the associated DICOM file will be deleted.
-* `-d, --dicomfix-config TEXT`: JSON file to correct DICOM fields. USE WITH CAUTION
-* `--export-refaced`: Prefer REFACED_DICOM where available; otherwise export standard DICOM
+* `-d, --dicomfix-config <str>`: JSON file to correct DICOM fields. USE WITH CAUTION
+* `--force-non-defaced`: Export original DICOM when REFACED_DICOM is available
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/tests/unit/test_bids_utils.py
+++ b/tests/unit/test_bids_utils.py
@@ -6,6 +6,7 @@ import responses
 
 from xnat_tools import bids_utils as utils
 from xnat_tools.bids_utils import (
+    add_rec_refaced_entity,
     bidsify_dicom_headers,
     bidsmap_scans,
     check_fmap_acquistion_tags,
@@ -97,6 +98,34 @@ def test_bidsmap_scans_run_plus():
     scans = [("1", "run+"), ("2", "run+"), ("3", "run+")]
 
     assert bidsmap_scans(scans) == [("1", "run-01"), ("2", "run-02"), ("3", "run-03")]
+
+
+def test_add_rec_refaced_entity_for_refaced_exports():
+    assert (
+        add_rec_refaced_entity("func_task-rest_run-01_bold", "REFACED_DICOM")
+        == "func_task-rest_rec-refaced_run-01_bold"
+    )
+
+
+def test_add_rec_refaced_entity_noop_for_non_refaced_exports():
+    assert (
+        add_rec_refaced_entity("anat_acq-MPRAGE_T1w", "DICOM")
+        == "anat_acq-MPRAGE_T1w"
+    )
+
+
+def test_add_rec_refaced_entity_no_duplicate():
+    assert (
+        add_rec_refaced_entity("func_task-rest_rec-refaced_run-01_bold", "REFACED_DICOM")
+        == "func_task-rest_rec-refaced_run-01_bold"
+    )
+
+
+def test_add_rec_refaced_entity_after_ce_before_run():
+    assert (
+        add_rec_refaced_entity("func_task-rest_acq-spiral_ce-gad_run-01_bold", "REFACED_DICOM")
+        == "func_task-rest_acq-spiral_ce-gad_rec-refaced_run-01_bold"
+    )
 
 
 def test_bidsify_dicom_headers_with_protocol_name(mocker):
@@ -288,6 +317,69 @@ def test_scan_contains_dicom_many_file_count():
     connection = requests.Session()
 
     assert scan_contains_dicom(connection, host, session, scanid) is True
+
+
+@responses.activate
+def test_scan_contains_dicom_prefers_refaced_by_default():
+    """Default mode should prefer REFACED_DICOM when available."""
+    host = "https://example.com/xnat"
+    session = "SESSION-01"
+    scanid = "SCAN-01"
+
+    url = f"{host}/data/experiments/{session}/scans/{scanid}/resources"
+    payload = {
+        "ResultSet": {
+            "Result": [
+                {
+                    "file_count": "10",
+                    "label": "DICOM",
+                    "format": "DICOM",
+                },
+                {
+                    "file_count": "10",
+                    "label": "REFACED_DICOM",
+                    "format": "DICOM",
+                },
+            ],
+        }
+    }
+
+    responses.add(responses.GET, url, json=payload, status=200)
+    connection = requests.Session()
+
+    assert scan_contains_dicom(connection, host, session, scanid) is True
+
+
+@responses.activate
+def test_scan_contains_dicom_force_non_defaced_prefers_standard_dicom():
+    """force_non_defaced should select standard DICOM over REFACED_DICOM."""
+    host = "https://example.com/xnat"
+    session = "SESSION-01"
+    scanid = "SCAN-01"
+
+    url = f"{host}/data/experiments/{session}/scans/{scanid}/resources"
+    payload = {
+        "ResultSet": {
+            "Result": [
+                {
+                    "file_count": "0",
+                    "label": "DICOM",
+                    "format": "DICOM",
+                },
+                {
+                    "file_count": "10",
+                    "label": "REFACED_DICOM",
+                    "format": "DICOM",
+                }
+            ],
+        }
+    }
+
+    responses.add(responses.GET, url, json=payload, status=200)
+    connection = requests.Session()
+
+    assert scan_contains_dicom(connection, host, session, scanid) is True
+    assert scan_contains_dicom(connection, host, session, scanid, force_non_defaced=True) is False
 
 
 def test_check_fmap_acquistion_tags():

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -19,16 +19,27 @@ from xnat_tools.xnat_utils import download, get
 _logger = logging.getLogger(__name__)
 
 
-def _select_dicom_resource(resources, export_refaced=False):
+def _select_dicom_resource(resources, force_non_defaced=False):
     """Select the DICOM resource to export for a scan."""
-    if export_refaced:
+    if not force_non_defaced:
         # REFACED_DICOM resources on XNAT may not populate format/content fields.
         # Match on label directly so preferred refaced export can find them reliably.
         refaced_resources = [r for r in resources if r.get("label") == "REFACED_DICOM"]
         if len(refaced_resources) == 1:
             return refaced_resources[0]
+    else:
+        # In force-non-defaced mode, prefer the original DICOM resource by label.
+        original_resources = [r for r in resources if r.get("label") == "DICOM"]
+        if len(original_resources) == 1:
+            return original_resources[0]
 
-    dicom_resources = [r for r in resources if r["format"] == "DICOM"]
+    dicom_resources = [r for r in resources if r.get("format") == "DICOM"]
+
+    # If multiple DICOM-format resources are present, prefer the standard DICOM label.
+    if len(dicom_resources) > 1:
+        labeled_dicom = [r for r in dicom_resources if r.get("label") == "DICOM"]
+        if len(labeled_dicom) == 1:
+            return labeled_dicom[0]
 
     if len(dicom_resources) != 1:
         return None
@@ -452,6 +463,29 @@ def handle_scanner_exceptions(match):
     return match
 
 
+def add_rec_refaced_entity(series_description: str, resource_label: str) -> str:
+    """Add rec-refaced to the BIDS series description for refaced DICOM exports."""
+    if resource_label != "REFACED_DICOM":
+        return series_description
+
+    if "rec-refaced" in series_description:
+        return series_description
+
+    tokens = series_description.split("_")
+
+    # Canonical ordering is sub/ses/task/acq/ce/rec/dir/run/mod/echo/flip/inv/mt.
+    # Since we are inserting rec, anchor it before the first post-rec entity.
+    insertion_prefixes = ("dir-", "run-", "mod-", "echo-", "flip-", "inv-", "mt-")
+    insert_idx = len(tokens) - 1 if len(tokens) > 1 else len(tokens)
+    for idx, token in enumerate(tokens):
+        if token.startswith(insertion_prefixes):
+            insert_idx = idx
+            break
+
+    tokens.insert(insert_idx, "rec-refaced")
+    return "_".join(tokens)
+
+
 def add_magphase_part_entity(allscans, filename, series_description):
     # heudiconv/reproin do this automatically if magnitude and phase
     # data are included in a single series, but we have to do it manually
@@ -503,7 +537,7 @@ def bidsify_dicom_headers(filename, series_description):
         dataset.save_as(filename)
 
 
-def scan_contains_dicom(connection, host, session, scanid, export_refaced=False):
+def scan_contains_dicom(connection, host, session, scanid, force_non_defaced=False):
     """Checks to see if the scan has suitable DICOM files for BIDS conversion"""
     resp = get(
         connection,
@@ -514,7 +548,9 @@ def scan_contains_dicom(connection, host, session, scanid, export_refaced=False)
     resources = resp.json()["ResultSet"]["Result"]
     _logger.debug(f"Resources for scan {scanid}: {resources}")
 
-    dicomResource = _select_dicom_resource(resources, export_refaced=export_refaced)
+    dicomResource = _select_dicom_resource(
+        resources, force_non_defaced=force_non_defaced
+    )
     _logger.debug(f"Selected DICOM resource for scan {scanid}: {dicomResource}")
     if dicomResource is None:
         return False
@@ -647,7 +683,14 @@ def validate_frame_counts(scans: list, bids_session_dir: str) -> None:
                         os.remove(partial_file_path)
 
 
-def list_xnat_resources(connection, host, resourcesURL, filetype=None, export_refaced=False):
+def list_xnat_resources(
+    connection,
+    host,
+    resourcesURL,
+    filetype=None,
+    force_non_defaced=False,
+    return_resource_label=False,
+):
     resp = get(
         connection,
         resourcesURL,
@@ -660,7 +703,9 @@ def list_xnat_resources(connection, host, resourcesURL, filetype=None, export_re
         label = "MRS"
         resourceList = [r for r in resources if r["label"] == label]
     elif filetype == "DICOM":
-        dicom_resource = _select_dicom_resource(resources, export_refaced=export_refaced)
+        dicom_resource = _select_dicom_resource(
+            resources, force_non_defaced=force_non_defaced
+        )
         if dicom_resource is None:
             return None
         resourceList = [dicom_resource]
@@ -692,6 +737,9 @@ def list_xnat_resources(connection, host, resourcesURL, filetype=None, export_re
     for resource in r.json()["ResultSet"]["Result"]:
         fileDict[resource["Name"]]["absolutePath"] = resource["absolutePath"]
 
+    if return_resource_label and filetype == "DICOM":
+        return fileDict, label
+
     return fileDict
 
 
@@ -702,7 +750,7 @@ def assign_bids_name(
     scans,
     build_dir,
     bids_session_dir,
-    export_refaced=False,
+    force_non_defaced=False,
 ):
     """
     subject: Subject to process
@@ -714,11 +762,29 @@ def assign_bids_name(
 
     for scanid, seriesdesc in scans:
         if not scan_contains_dicom(
-            connection, host, session, scanid, export_refaced=export_refaced
+            connection, host, session, scanid, force_non_defaced=force_non_defaced
         ):
             continue
 
-        # BIDS sourcedatadirectory for this scan
+        resourcesURL = host + f"/data/experiments/{session}/scans/{scanid}/resources/"
+
+        dicom_resources = list_xnat_resources(
+            connection,
+            host,
+            resourcesURL,
+            filetype="DICOM",
+            force_non_defaced=force_non_defaced,
+            return_resource_label=True,
+        )
+        if not dicom_resources:
+            _logger.info(f"No suitable DICOM resources found for scan {scanid}. Skipping.")
+            os.chdir(build_dir)
+            continue
+
+        dicomFileDict, selected_resource_label = dicom_resources
+        seriesdesc = add_rec_refaced_entity(seriesdesc, selected_resource_label)
+
+        # BIDS sourcedata directory for this scan
         _logger.info(f"bids_session_dir: {bids_session_dir}")
         _logger.info(f"BIDSNAME: {seriesdesc}")
         bids_scan_directory = os.path.join(bids_session_dir, seriesdesc)
@@ -732,20 +798,6 @@ def assign_bids_name(
                 See documentation to understand behavior for repeated sequences."
             )
         os.chdir(bids_scan_directory)
-
-        resourcesURL = host + f"/data/experiments/{session}/scans/{scanid}/resources/"
-
-        dicomFileDict = list_xnat_resources(
-            connection,
-            host,
-            resourcesURL,
-            filetype="DICOM",
-            export_refaced=export_refaced,
-        )
-        if not dicomFileDict:
-            _logger.info(f"No suitable DICOM resources found for scan {scanid}. Skipping.")
-            os.chdir(build_dir)
-            continue
 
         # Download DICOMs
         _logger.info("Downloading files")

--- a/xnat_tools/bids_utils.py
+++ b/xnat_tools/bids_utils.py
@@ -19,6 +19,23 @@ from xnat_tools.xnat_utils import download, get
 _logger = logging.getLogger(__name__)
 
 
+def _select_dicom_resource(resources, export_refaced=False):
+    """Select the DICOM resource to export for a scan."""
+    if export_refaced:
+        # REFACED_DICOM resources on XNAT may not populate format/content fields.
+        # Match on label directly so preferred refaced export can find them reliably.
+        refaced_resources = [r for r in resources if r.get("label") == "REFACED_DICOM"]
+        if len(refaced_resources) == 1:
+            return refaced_resources[0]
+
+    dicom_resources = [r for r in resources if r["format"] == "DICOM"]
+
+    if len(dicom_resources) != 1:
+        return None
+
+    return dicom_resources[0]
+
+
 def insert_intended_for_fmap(
     bids_dir,
     sub_list,
@@ -486,7 +503,7 @@ def bidsify_dicom_headers(filename, series_description):
         dataset.save_as(filename)
 
 
-def scan_contains_dicom(connection, host, session, scanid):
+def scan_contains_dicom(connection, host, session, scanid, export_refaced=False):
     """Checks to see if the scan has suitable DICOM files for BIDS conversion"""
     resp = get(
         connection,
@@ -494,19 +511,13 @@ def scan_contains_dicom(connection, host, session, scanid):
         params={"format": "json"},
     )
 
-    dicomResourceList = [r for r in resp.json()["ResultSet"]["Result"] if r["format"] == "DICOM"]
-    _logger.debug(f"Found DICOM resources: {dicomResourceList}")
-    # NOTE (BNR): A scan contains multiple resources. A resource can be thought
-    #             of as a folder. We only want a single DICOM folder. If we have
-    #             multiple, something is weird. If we don't have any DICOM
-    #             resources the scan doesn't have any DICOM images. We only
-    #             download the scan if there's a single DICOM resource
-    if len(dicomResourceList) <= 0:
+    resources = resp.json()["ResultSet"]["Result"]
+    _logger.debug(f"Resources for scan {scanid}: {resources}")
+
+    dicomResource = _select_dicom_resource(resources, export_refaced=export_refaced)
+    _logger.debug(f"Selected DICOM resource for scan {scanid}: {dicomResource}")
+    if dicomResource is None:
         return False
-    elif len(dicomResourceList) > 1:
-        return False
-    else:
-        dicomResource = dicomResourceList[0]
 
     # NOTE (BNR): We only want to process the scan if we have dicom files. But
     #       sometimes the file_count field is empty and we process anyway even
@@ -636,7 +647,7 @@ def validate_frame_counts(scans: list, bids_session_dir: str) -> None:
                         os.remove(partial_file_path)
 
 
-def list_xnat_resources(connection, host, resourcesURL, filetype=None):
+def list_xnat_resources(connection, host, resourcesURL, filetype=None, export_refaced=False):
     resp = get(
         connection,
         resourcesURL,
@@ -649,10 +660,11 @@ def list_xnat_resources(connection, host, resourcesURL, filetype=None):
         label = "MRS"
         resourceList = [r for r in resources if r["label"] == label]
     elif filetype == "DICOM":
-        # limit the resources to ones that are DICOM format
-        resourceList = [r for r in resources if r["format"] == "DICOM"]
-        # check the label of our one DICOM resource
-        label = resourceList[0]["label"]
+        dicom_resource = _select_dicom_resource(resources, export_refaced=export_refaced)
+        if dicom_resource is None:
+            return None
+        resourceList = [dicom_resource]
+        label = dicom_resource["label"]
     else:
         _logger.warning("Unknown XNAT filetype. Must be 'DICOM' or 'rawMRS'.")
         return None
@@ -690,6 +702,7 @@ def assign_bids_name(
     scans,
     build_dir,
     bids_session_dir,
+    export_refaced=False,
 ):
     """
     subject: Subject to process
@@ -700,7 +713,9 @@ def assign_bids_name(
     # Build a dict keyed off file name
 
     for scanid, seriesdesc in scans:
-        if not scan_contains_dicom(connection, host, session, scanid):
+        if not scan_contains_dicom(
+            connection, host, session, scanid, export_refaced=export_refaced
+        ):
             continue
 
         # BIDS sourcedatadirectory for this scan
@@ -720,7 +735,17 @@ def assign_bids_name(
 
         resourcesURL = host + f"/data/experiments/{session}/scans/{scanid}/resources/"
 
-        dicomFileDict = list_xnat_resources(connection, host, resourcesURL, filetype="DICOM")
+        dicomFileDict = list_xnat_resources(
+            connection,
+            host,
+            resourcesURL,
+            filetype="DICOM",
+            export_refaced=export_refaced,
+        )
+        if not dicomFileDict:
+            _logger.info(f"No suitable DICOM resources found for scan {scanid}. Skipping.")
+            os.chdir(build_dir)
+            continue
 
         # Download DICOMs
         _logger.info("Downloading files")

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -102,6 +102,11 @@ def dicom_export(
     correct_dicoms_config: str = typer.Option(
         "", "-d", "--dicomfix-config", help="JSON file to correct DICOM fields. USE WITH CAUTION"
     ),
+    export_refaced: bool = typer.Option(
+        False,
+        "--export-refaced",
+        help="Prefer REFACED_DICOM where available; otherwise export standard DICOM",
+    ),
 ):
 
     """
@@ -164,6 +169,7 @@ def dicom_export(
         scans,
         build_dir,
         export_session_dir,
+        export_refaced=export_refaced,
     )
 
     if validate_frames:

--- a/xnat_tools/dicom_export.py
+++ b/xnat_tools/dicom_export.py
@@ -102,10 +102,10 @@ def dicom_export(
     correct_dicoms_config: str = typer.Option(
         "", "-d", "--dicomfix-config", help="JSON file to correct DICOM fields. USE WITH CAUTION"
     ),
-    export_refaced: bool = typer.Option(
+    force_non_defaced: bool = typer.Option(
         False,
-        "--export-refaced",
-        help="Prefer REFACED_DICOM where available; otherwise export standard DICOM",
+        "--force-non-defaced",
+        help="Export original DICOM when REFACED_DICOM is available",
     ),
 ):
 
@@ -169,7 +169,7 @@ def dicom_export(
         scans,
         build_dir,
         export_session_dir,
-        export_refaced=export_refaced,
+        force_non_defaced=force_non_defaced,
     )
 
     if validate_frames:

--- a/xnat_tools/xnat2bids.py
+++ b/xnat_tools/xnat2bids.py
@@ -89,10 +89,10 @@ def xnat2bids(
     correct_dicoms_config: str = typer.Option(
         "", "-d", "--dicomfix-config", help="JSON file to correct DICOM fields. USE WITH CAUTION"
     ),
-    export_refaced: bool = typer.Option(
+    force_non_defaced: bool = typer.Option(
         False,
-        "--export-refaced",
-        help="Prefer REFACED_DICOM where available; otherwise export standard DICOM",
+        "--force-non-defaced",
+        help="Export original DICOM when REFACED_DICOM is available",
     ),
 ):
     """
@@ -116,7 +116,7 @@ def xnat2bids(
             overwrite=overwrite,
             validate_frames=validate_frames,
             correct_dicoms_config=correct_dicoms_config,
-            export_refaced=export_refaced,
+            force_non_defaced=force_non_defaced,
         )
 
     if not export_only:

--- a/xnat_tools/xnat2bids.py
+++ b/xnat_tools/xnat2bids.py
@@ -89,6 +89,11 @@ def xnat2bids(
     correct_dicoms_config: str = typer.Option(
         "", "-d", "--dicomfix-config", help="JSON file to correct DICOM fields. USE WITH CAUTION"
     ),
+    export_refaced: bool = typer.Option(
+        False,
+        "--export-refaced",
+        help="Prefer REFACED_DICOM where available; otherwise export standard DICOM",
+    ),
 ):
     """
     Export DICOM images from an XNAT experiment to a BIDS compliant directory
@@ -111,6 +116,7 @@ def xnat2bids(
             overwrite=overwrite,
             validate_frames=validate_frames,
             correct_dicoms_config=correct_dicoms_config,
+            export_refaced=export_refaced,
         )
 
     if not export_only:


### PR DESCRIPTION
## Adding Flag to Export Refaced Images Only

This PR extends the `xnat2bids` pipeline by adding the `export-refaced` flag.  If the flag is supplied, only scan-level resources with the label REFACED_DICOM will be exported.  Other scan resources, e.g. original DICOM images, will be left alone. 